### PR TITLE
ツール定義をResponses API形式に変換

### DIFF
--- a/lib/discord_bot/llm.ex
+++ b/lib/discord_bot/llm.ex
@@ -12,7 +12,7 @@ defmodule DiscordBot.Llm do
   end
 
   defp chat_with_model_repeatedly(input, tools) do
-    tool_definitions = Enum.map(tools, & &1.definition)
+    tool_definitions = Enum.map(tools, &convert_tool_definition/1)
 
     opts = [
       instructions: History.instructions(),
@@ -35,6 +35,21 @@ defmodule DiscordBot.Llm do
           )
 
         chat_with_model_repeatedly(input, tools)
+    end
+  end
+
+  defp convert_tool_definition(%{definition: definition}) do
+    case definition do
+      %{"function" => function} ->
+        %{
+          "type" => "function",
+          "name" => function["name"],
+          "description" => function["description"],
+          "parameters" => function["parameters"]
+        }
+
+      _ ->
+        definition
     end
   end
 


### PR DESCRIPTION
## Summary
- Chat Completions API形式のツール定義をResponses API形式に変換する処理を追加
- Responses APIでは`function`のネストがなく、直接`name`, `description`, `parameters`を指定する必要がある

## Test plan
- [x] ローカルでツール定義の変換ロジックを確認
- [x] ローカルでResponses API形式のツールを使ったAPI呼び出しを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)