### PR TITLE
Fix slow response by using cache instead of API call

### DIFF
--- a/lib/discord_bot/adapter/api.ex
+++ b/lib/discord_bot/adapter/api.ex
@@ -18,8 +18,7 @@ defmodule DiscordBot.Adapter.Api.Impl do
 
   @impl DiscordBot.Adapter.Api.Behaviour
   def get_current_user!() do
-    {:ok, user} = Nostrum.Api.Self.get()
-    user
+    Nostrum.Cache.Me.get()
   end
 
   @impl DiscordBot.Adapter.Api.Behaviour


### PR DESCRIPTION
## Summary
- `get_current_user!()` が毎回 `Nostrum.Api.Self.get()` を呼び出していたため、メッセージ受信のたびに Discord API へリクエストが発生していた
- 時間経過とともにレートリミットに達し、リクエストがキューに溜まって遅延が蓄積
- `Nostrum.Cache.Me.get()` を使用するよう変更し、メモリキャッシュから読み取るように修正
