### PR TITLE
Fix missing error handling for OpenAI API responses

### DIFF
--- a/lib/discord_bot/llm/openai_client.ex
+++ b/lib/discord_bot/llm/openai_client.ex
@@ -1,4 +1,6 @@
 defmodule DiscordBot.Llm.OpenAIClient do
+  require Logger
+
   alias DiscordBot.HttpClient
 
   @endpoint "https://api.openai.com/v1/responses"
@@ -44,6 +46,11 @@ defmodule DiscordBot.Llm.OpenAIClient do
       {:function_calls, calls} ->
         {:tool_calls, %{"tool_calls" => calls}, usage}
     end
+  end
+
+  defp handle_response(%{status: status, body: body}) do
+    Logger.error("OpenAI API error: status=#{status}, body=#{inspect(body)}")
+    {:error, "APIエラーが発生しました（ステータス: #{status}）"}
   end
 
   defp extract_result(output) do


### PR DESCRIPTION
## Summary
- OpenAI APIがエラーを返した際にプロセスがクラッシュする問題を修正
- `openai_client.ex`に非200ステータスのハンドラーを追加
- `llm.ex`に予期しないレスポンス用のcatch-allパターンを追加
