### PR TITLE
Fix OpenAI client tests to match Responses API format

### DIFF
--- a/test/discord_bot/llm/openai_client_test.exs
+++ b/test/discord_bot/llm/openai_client_test.exs
@@ -1,6 +1,7 @@
 defmodule DiscordBot.Llm.OpenAiClientTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
   import Mox
 
   alias DiscordBot.Infra.HttpClient.Mock
@@ -9,36 +10,99 @@ defmodule DiscordBot.Llm.OpenAiClientTest do
   setup :verify_on_exit!
 
   describe "ask_model/2" do
-    test "returns response from OpenAI API" do
+    test "returns message response from OpenAI Responses API" do
       expect(Mock, :post!, 1, fn _endpoint, _body ->
         %{
           status: 200,
           body: %{
-            "choices" => [%{"finish_reason" => "stop", "message" => "response"}],
+            "output" => [
+              %{
+                "type" => "message",
+                "content" => [%{"type" => "text", "text" => "Hello, world!"}]
+              }
+            ],
             "usage" => %{"total_tokens" => 10}
           }
         }
       end)
 
-      assert OpenAIClient.ask_model([], []) == {:stop, "response", %{"total_tokens" => 10}}
+      assert OpenAIClient.ask_model([]) ==
+               {:stop, %{"content" => "Hello, world!"}, %{"total_tokens" => 10}}
     end
 
-    test "returns response from OpenAI API with tools" do
+    test "returns tool_calls response when function_call is present" do
+      expect(Mock, :post!, 1, fn _endpoint, _body ->
+        %{
+          status: 200,
+          body: %{
+            "output" => [
+              %{
+                "type" => "function_call",
+                "call_id" => "call_abc123",
+                "name" => "get_weather",
+                "arguments" => ~s({"location": "Tokyo"})
+              }
+            ],
+            "usage" => %{"total_tokens" => 15}
+          }
+        }
+      end)
+
+      assert OpenAIClient.ask_model([]) ==
+               {:tool_calls,
+                %{
+                  "tool_calls" => [
+                    %{
+                      "id" => "call_abc123",
+                      "function" => %{
+                        "name" => "get_weather",
+                        "arguments" => ~s({"location": "Tokyo"})
+                      }
+                    }
+                  ]
+                }, %{"total_tokens" => 15}}
+    end
+
+    test "passes tools option to the API" do
+      tool_definitions = [%{"type" => "function", "name" => "test_tool"}]
+
       expect(Mock, :post!, 1, fn _endpoint, body ->
         assert {:ok, json} = Keyword.fetch(body, :json)
-        assert json["tools"] == ["tool"]
+        assert json["tools"] == tool_definitions
 
         %{
           status: 200,
           body: %{
-            "choices" => [%{"finish_reason" => "stop", "message" => "response"}],
+            "output" => [
+              %{"type" => "message", "content" => [%{"type" => "text", "text" => "response"}]}
+            ],
             "usage" => %{"total_tokens" => 10}
           }
         }
       end)
 
-      assert OpenAIClient.ask_model([], tools: ["tool"]) ==
-               {:stop, "response", %{"total_tokens" => 10}}
+      assert {:stop, _, _} = OpenAIClient.ask_model([], tools: tool_definitions)
+    end
+
+    test "returns error tuple on rate limit error" do
+      expect(Mock, :post!, 1, fn _endpoint, _body ->
+        %{
+          status: 429,
+          body: %{
+            "error" => %{
+              "message" => "Rate limit reached for default-gpt-4o in organization",
+              "type" => "rate_limit_error"
+            }
+          }
+        }
+      end)
+
+      log =
+        capture_log(fn ->
+          assert {:error, "APIエラーが発生しました（ステータス: 429）"} = OpenAIClient.ask_model([])
+        end)
+
+      assert log =~ "OpenAI API error: status=429"
     end
   end
 end


### PR DESCRIPTION
## Summary
- OpenAIClientのテストが古いChat Completions API形式を使用していたため、現在の実装（Responses API）に合わせて修正
- function_callレスポンスのテストケースを追加
- エラーケース（429 Rate Limit）のテストを追加し、`capture_log`でログ出力を抑制

## Test plan
- [x] `mix test test/discord_bot/llm/openai_client_test.exs` が全て通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)