### PR TITLE
Fix auto-merge to detect runtime dev dependencies

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -83,10 +83,17 @@ jobs:
 
           is_dev=false
 
-          # Check in mix.exs for Elixir deps with only: :dev or only: :test or only: [:dev, :test]
           if [ -f "mix.exs" ]; then
-            if grep -E "{:$DEP_NAME," mix.exs | grep -qE "only:.*(:dev|:test)"; then
-              echo "Found in mix.exs as dev/test dependency"
+            dep_line=$(grep -E "{:$DEP_NAME," mix.exs || true)
+            echo "Dependency line: $dep_line"
+
+            # Check for only: :dev or only: :test or only: [:dev, :test]
+            if echo "$dep_line" | grep -qE "only:.*(:dev|:test)"; then
+              echo "Found in mix.exs as dev/test dependency (only:)"
+              is_dev=true
+            # Check for runtime: Mix.env() == :dev (build tools like esbuild/tailwind)
+            elif echo "$dep_line" | grep -qE "runtime:.*Mix\.env\(\).*==.*:dev"; then
+              echo "Found in mix.exs as dev runtime dependency"
               is_dev=true
             fi
           fi


### PR DESCRIPTION
## Summary
- `runtime: Mix.env() == :dev` パターンをdev依存として検出するよう修正
- `esbuild`や`tailwind`などのビルドツールが正しくdev依存として判定されるようになる

## Background
Phoenixの標準テンプレートでは、`esbuild`と`tailwind`は`only: :dev`ではなく`runtime: Mix.env() == :dev`形式で指定されています。これは本番ビルド時にも必要だが、ランタイムでは不要なためです。

## Test plan
- [ ] PR #66 (esbuild) がdev依存として判定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)