### PR TITLE
Work around Nostrum API timeout issue by using direct REST API calls

### DIFF
--- a/lib/discord_bot/discord/api.ex
+++ b/lib/discord_bot/discord/api.ex
@@ -10,10 +10,25 @@ end
 
 defmodule DiscordBot.Discord.Api.Impl do
   @behaviour DiscordBot.Discord.Api.Behaviour
+  require Logger
+
+  alias DiscordBot.Infra.HttpClient
+
+  # Nostrum 0.10.x has a bug where HTTP connections hang after long idle periods (GitHub issue #680)
+  # Using direct REST API calls until this is fixed in 0.11
+  # After the fix, uncomment the following and remove the xxx_direct calls
+  #
+  # def create_message(channel_id, content) do
+  #   Nostrum.Api.Message.create(channel_id, content)
+  # end
+  #
+  # def start_typing!(channel_id) do
+  #   Nostrum.Api.Channel.start_typing(channel_id)
+  # end
 
   @impl DiscordBot.Discord.Api.Behaviour
   def create_message(channel_id, content) do
-    Nostrum.Api.Message.create(channel_id, content)
+    create_message_direct(channel_id, content)
   end
 
   @impl DiscordBot.Discord.Api.Behaviour
@@ -23,7 +38,55 @@ defmodule DiscordBot.Discord.Api.Impl do
 
   @impl DiscordBot.Discord.Api.Behaviour
   def start_typing!(channel_id) do
-    Nostrum.Api.Channel.start_typing(channel_id)
+    start_typing_direct(channel_id)
+  end
+
+  defp create_message_direct(channel_id, content) do
+    url = "https://discord.com/api/v10/channels/#{channel_id}/messages"
+    body = build_message_body(content)
+
+    case HttpClient.post(url, headers: discord_headers(), json: body) do
+      {:ok, %{status: status}} when status in 200..299 ->
+        {:ok, :sent_via_rest}
+
+      {:ok, %{status: status, body: body}} ->
+        Logger.error("Discord REST API error: status=#{status}, body=#{inspect(body)}")
+        {:error, body}
+
+      {:error, error} ->
+        Logger.error("Discord REST API request failed: #{inspect(error)}")
+        {:error, error}
+    end
+  end
+
+  defp start_typing_direct(channel_id) do
+    url = "https://discord.com/api/v10/channels/#{channel_id}/typing"
+
+    case HttpClient.post(url, headers: discord_headers(), json: %{}) do
+      {:ok, %{status: status}} when status in 200..299 ->
+        {:ok}
+
+      {:ok, %{status: status, body: body}} ->
+        Logger.error("Discord REST API typing error: status=#{status}, body=#{inspect(body)}")
+        {:error, body}
+
+      {:error, error} ->
+        Logger.error("Discord REST API typing request failed: #{inspect(error)}")
+        {:error, error}
+    end
+  end
+
+  defp build_message_body(content) when is_binary(content), do: %{"content" => content}
+  defp build_message_body(%{content: text}), do: %{"content" => text}
+  defp build_message_body(content), do: %{"content" => inspect(content)}
+
+  defp discord_headers do
+    token = Application.get_env(:nostrum, :token)
+
+    [
+      {"Content-Type", "application/json"},
+      {"Authorization", "Bot #{token}"}
+    ]
   end
 end
 

--- a/lib/discord_bot/discord/event_listener.ex
+++ b/lib/discord_bot/discord/event_listener.ex
@@ -13,7 +13,7 @@ defmodule DiscordBot.Discord.EventListener do
           Api.create_message(msg.channel_id, generate_dice_roll_message(result, msg))
 
         {:other, true} ->
-          Api.start_typing!(msg.channel_id)
+          Task.start(fn -> Api.start_typing!(msg.channel_id) end)
 
           Api.create_message(
             msg.channel_id,
@@ -26,7 +26,9 @@ defmodule DiscordBot.Discord.EventListener do
     end
   end
 
-  def handle_event(_event), do: :ignore
+  def handle_event(_event) do
+    :ignore
+  end
 
   def need_evaluate?(content) do
     Regex.scan(~r/<@\d+>/, content)

--- a/lib/discord_bot/infra/http_client.ex
+++ b/lib/discord_bot/infra/http_client.ex
@@ -6,14 +6,24 @@ end
 defmodule DiscordBot.Infra.HttpClient.Impl do
   @behaviour DiscordBot.Infra.HttpClient.Behaviour
 
+  defp default_options do
+    [
+      pool_timeout: 5_000,
+      receive_timeout: 60_000,
+      retry: :transient,
+      retry_delay: &(&1 * 1_000),
+      max_retries: 2
+    ]
+  end
+
   @impl DiscordBot.Infra.HttpClient.Behaviour
   def post(url, options) do
-    Req.post(url, options)
+    Req.post(url, Keyword.merge(default_options(), options))
   end
 
   @impl DiscordBot.Infra.HttpClient.Behaviour
   def post!(url, options) do
-    Req.post!(url, options)
+    Req.post!(url, Keyword.merge(default_options(), options))
   end
 end
 


### PR DESCRIPTION
## Summary
- Nostrum 0.10.x has a bug where HTTP connections hang after long idle periods ([GitHub issue #680](https://github.com/Kraigie/nostrum/issues/680))
- This causes the bot to become unresponsive when trying to send messages or typing indicators
- Use direct Discord REST API calls instead of Nostrum.Api until 0.11 is released with the fix

## Changes
- Use direct Discord REST API calls for `create_message` and `start_typing`
- Add timeout and retry settings to HttpClient for robustness
- Make `start_typing` async to avoid blocking message processing

## Test plan
- [x] Verify bot responds to mentions immediately after startup
- [x] Verify bot responds to mentions after long idle period (30+ minutes)
- [x] Verify typing indicator appears before response

🤖 Generated with [Claude Code](https://claude.com/claude-code)